### PR TITLE
fix a bug in gmt_destriping for choosing CHENP4M6 method

### DIFF
--- a/GRACE_functions/gmt_destriping.m
+++ b/GRACE_functions/gmt_destriping.m
@@ -41,7 +41,7 @@ elseif strcmp(destrip_method,'CHENP3M6')
     sc_destrip = gmt_destriping_chen(field,'CHENP3M6');
     cs_destrip=gmt_sc2cs(sc_destrip);
 elseif strcmp(destrip_method,'CHENP4M6')
-    sc_destrip = gmt_destriping_chen(field,'CHENP3M6');
+    sc_destrip = gmt_destriping_chen(field,'CHENP4M6');
     cs_destrip=gmt_sc2cs(sc_destrip);
 elseif strcmp(destrip_method,'DUAN')
     pair1=35;


### PR DESCRIPTION
Fixed a bug in gmt_destriping line 43-44 "elseif strcmp(destrip_method,'CHENP4M6') sc_destrip = gmt_destriping_chen(field,'CHENP3M6')", should be "gmt_destriping_chen(field,'CHENP4M6')"